### PR TITLE
86 STORY-2785 adwords detail request optimization updates

### DIFF
--- a/adwords_api/Gemfile
+++ b/adwords_api/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+ruby '2.1.2'

--- a/adwords_api/Gemfile.lock
+++ b/adwords_api/Gemfile.lock
@@ -1,0 +1,58 @@
+PATH
+  remote: .
+  specs:
+    google-adwords-api (0.14.2)
+      google-ads-common (~> 0.9.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    akami (1.2.2)
+      gyoku (>= 0.4.0)
+      nokogiri
+    builder (3.2.2)
+    extlib (0.9.16)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    google-ads-common (0.9.9)
+      httpi (~> 1.1.0)
+      savon (~> 1.2.0)
+      signet (~> 0.6.0)
+    gyoku (0.4.6)
+      builder (>= 2.1.2)
+    httpi (1.1.1)
+      rack
+    jwt (1.5.1)
+    mini_portile (0.6.2)
+    multi_json (1.11.2)
+    multipart-post (2.0.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    nori (1.1.5)
+    rack (1.6.4)
+    rake (10.3.2)
+    savon (1.2.0)
+      akami (~> 1.2.0)
+      builder (>= 2.1.2)
+      gyoku (~> 0.4.5)
+      httpi (~> 1.1.0)
+      nokogiri (>= 1.4.0)
+      nori (~> 1.1.0)
+      wasabi (~> 2.5.0)
+    signet (0.6.1)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    wasabi (2.5.1)
+      httpi (~> 1.0)
+      nokogiri (>= 1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-adwords-api!
+  rake (~> 10.3.2)

--- a/adwords_api/google-adwords-api.gemspec
+++ b/adwords_api/google-adwords-api.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
       %w(COPYING README.md ChangeLog adwords_api.yml)
   s.test_files = ['test/suite_unittests.rb']
   s.add_dependency('google-ads-common', '~> 0.9.8')
+  s.add_development_dependency('rake', '~> 10.3.2')
 end

--- a/adwords_api/lib/adwords_api/errors.rb
+++ b/adwords_api/lib/adwords_api/errors.rb
@@ -94,5 +94,26 @@ module AdwordsApi
         @field_path = error_field_path
       end
     end
+
+    # Error for server-side rate exceeded error.
+    class RateExceededError < AdsCommon::Errors::ApiException
+      attr_reader :http_code, :type, :trigger, :field_path, :reason, :rate_scope, :rate_name, :retry_after_seconds
+
+      def initialize(http_code, error_type, error_trigger, error_field_path, reason, rate_scope, rate_name, retry_after_seconds)
+        message =
+            "HTTP code: %d, error type: '%s', trigger: '%s', field path: '%s', reason: '%s', rate scope: '%s', rate name: '%s', retry after seconds: '%s'" %
+            [http_code, error_type, error_trigger, error_field_path, reason, rate_scope, rate_name, retry_after_seconds]
+        super(message)
+
+        @http_code = http_code
+        @type = error_type
+        @trigger = error_trigger
+        @field_path = error_field_path
+        @reason = reason
+        @rate_scope = rate_scope
+        @rate_name = rate_name
+        @retry_after_seconds = retry_after_seconds
+      end
+    end
   end
 end

--- a/adwords_api/lib/adwords_api/report_utils.rb
+++ b/adwords_api/lib/adwords_api/report_utils.rb
@@ -219,10 +219,12 @@ module AdwordsApi
       end
     end
 
+    # Checks for a rate exceeded error in the response body and raises an exception
+    # if it was found
     def check_for_rate_exceeded_error(report_body, response_code)
       error_response = Nori.parse(report_body)
-      if error_response.include?(:report_download_error) and
-          error_response[:report_download_error].include?(:api_error) and
+      if error_response.include?(:report_download_error) &&
+          error_response[:report_download_error].include?(:api_error) &&
           error_response[:report_download_error][:api_error][:type] == 'RateExceededError.RATE_EXCEEDED'
         rate_error = error_response[:report_download_error][:api_error]
         raise AdwordsApi::Errors::RateExceededError.new(response_code, rate_error[:type], rate_error[:trigger], rate_error[:field_path],

--- a/adwords_api/test/adwords_api/test_report_utils.rb
+++ b/adwords_api/test/adwords_api/test_report_utils.rb
@@ -204,4 +204,33 @@ class TestReportUtils < Test::Unit::TestCase
 
     assert_match /#{expected_msg}/, e.to_s
   end
+
+  # Testing check_for_rate_exceeded_error.
+  def test_check_for_rate_exceeded_error()
+    xml_reply = {
+      :reply => '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><reportDownloadError><ApiError><type>RateExceededError.RATE_EXCEEDED</type><trigger>foo</trigger><fieldPath>bar</fieldPath><reason>RateExceededError.Reason.RATE_EXCEEDED</reason><rateScope>scope</rateScope><rateName>rate name</rateName><retryAfterSeconds>60</retryAfterSeconds></ApiError></reportDownloadError>',
+      :type => 'RateExceededError.RATE_EXCEEDED',
+      :trigger => 'foo',
+      :field_path => 'bar',
+      :reason => 'RateExceededError.Reason.RATE_EXCEEDED',
+      :rate_scope => 'scope',
+      :rate_name => 'rate name',
+      :retry_after_seconds => '60'
+    }
+
+    begin
+      @report_utils.send(:check_for_rate_exceeded_error, xml_reply[:reply], 42)
+      assert(false, 'No exception thrown for code 42')
+    rescue AdwordsApi::Errors::RateExceededError => e
+      assert_equal(42, e.http_code)
+      assert_equal(xml_reply[:type], e.type)
+      assert_equal(xml_reply[:trigger], e.trigger)
+      assert_equal(xml_reply[:field_path], e.field_path)
+      assert_equal(xml_reply[:reason], e.reason)
+      assert_equal(xml_reply[:rate_scope], e.rate_scope)
+      assert_equal(xml_reply[:rate_name], e.rate_name)
+      assert_equal(xml_reply[:retry_after_seconds], e.retry_after_seconds)
+      assert_not_nil(e.message)
+    end
+  end
 end


### PR DESCRIPTION
@ibiziiac-sv this branch has the fixes you need to run tests. Add your changes + tests to this branch for CR.

Before running `rake test` in the adwords_api folder, copy adwords_api/adwords_api.yml to your ~/adwords_api.yml temporarily (for some reason it wants to use the home folder).
